### PR TITLE
Avoid synchronous X operations

### DIFF
--- a/x2x.c
+++ b/x2x.c
@@ -492,7 +492,7 @@ char **argv;
     } /* END if */
     sleep(10);
   } /* END while fromDpy */
-  (void)XSynchronize(fromDpy, True);
+  (void)XSync(fromDpy, False);
 
   /* toDpy is always the first shadow */
   pShadow = (PSHADOW)xmalloc(sizeof(SHADOW));
@@ -509,7 +509,7 @@ char **argv;
     if (!(pShadow->dpy = OpenAndCheckDisplay(pShadow->name)))
       exit(3);
   }
-  (void)XSynchronize(shadows->dpy, True);
+  (void)XSync(shadows->dpy, False);
 
 #ifndef WIN_2_X
   /* set error handler,


### PR DESCRIPTION
## Summary
- Replace XSynchronize with XSync when opening displays to avoid synchronous X11 round trips

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68b62bdb40f483338928a9aa87e5f79e