### PR TITLE
Optimize memory allocation by switching to calloc

### DIFF
--- a/x2x.c
+++ b/x2x.c
@@ -3690,10 +3690,13 @@ XSelectionEvent *pEv;
 static void *xmalloc(size)
 size_t size;
 {
-  void * ptr = malloc(size);
+  /* calloc() zeroes the requested memory in an optimized manner,
+   * avoiding an explicit memset() call after malloc().  This reduces
+   * overhead for allocations that require cleared memory. */
+  void *ptr = calloc(1, size);
   if (!ptr) {
     fprintf(stderr, "%s - error: %s\n", programStr, strerror(errno));
     exit(1);
   }
-  return memset(ptr, 0, size);
+  return ptr;
 }


### PR DESCRIPTION
## Summary
- Reduce allocation overhead by replacing malloc+memset with calloc in xmalloc

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68b62bdb40f483338928a9aa87e5f79e